### PR TITLE
leaflet 0.7.7 -> 1.9.4

### DIFF
--- a/www/page.php
+++ b/www/page.php
@@ -4,8 +4,8 @@
 <title><?=_('Level0 OpenStreetMap Editor') ?></title>
 <meta charset="utf-8">
 <meta name="generator" content="<?=GENERATOR ?>">
-<link rel="stylesheet" href="https://unpkg.com/leaflet@0.7.7/dist/leaflet.css" />
-<script src="https://unpkg.com/leaflet@0.7.7/dist/leaflet.js"></script>
+<link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="" />
+<script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
 <style>body { font-family: sans-serif; font-size: 11pt; }</style>
 </head>
 <body>

--- a/www/script.js
+++ b/www/script.js
@@ -50,13 +50,14 @@ document.addEventListener('DOMContentLoaded', () => {
 	};
 	L.Map.include(RestoreViewMixin);
 
-	var map = L.map('map');
+	var map = L.map('map', { attributionControl: false });
 	if (init_l0_map.force || !map.restoreView()) {
 		map.setView(init_l0_map.center, init_l0_map.zoom);
 	}
 
 	L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png',
-		{ attribution: 'Map &copy; <a href="https://www.openstreetmap.org">OpenStreetMap contributors</a>' }).addTo(map);
+		{ attribution: 'Map © <a href="https://www.openstreetmap.org">OpenStreetMap contributors</a>' }).addTo(map);
+	L.control.attribution({ prefix: null }).addTo(map);
 	var marker = L.marker(map.getCenter(), { draggable: true }).addTo(map);
 	var ways = L.layerGroup().addTo(map);
 


### PR DESCRIPTION
0.7.7 was released in year 2015. I expected more changes were needed but it's incredible backward compatible and everything still works. Minimum browser requirement is now MSIE11 but that's the same as the main openstreetmap.org website.