### PR TITLE
Github Actions: make sure config.php exists

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,4 +31,5 @@ jobs:
       - name: Run tests
         run: |
           composer validate
+          cp www/config.php.sample www/config.php
           ./vendor/bin/phpunit --display-warnings test/


### PR DESCRIPTION
This makes the tests pass on Github Actions again.