### PR TITLE
Update message ID to eliminate confusion with LAT/LON

### DIFF
--- a/messages.pot
+++ b/messages.pot
@@ -233,7 +233,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: www/page.php:28
-msgid "URL or group of IDs like \"n54,w33\""
+msgid "URL or group of IDs like \"n55667788,w66554433\""
 msgstr ""
 
 #: www/page.php:29


### PR DESCRIPTION
The current "n54,w33" looks like 54&deg; North, 33&deg; West!!

(Yes, even though on the line it does say 'IDs".)